### PR TITLE
Fix forward pass 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
 # FastKAN: Very Fast Implementation (Approximation) of Kolmogorov-Arnold Network
 
-Work in progress and as demo.
+*Work in progress*
 
-This repository contains a very fast implementation of Kolmogorov-Arnold Network (KAN).
+This repository contains a very fast implementation of Kolmogorov-Arnold Network (KAN). The forward time of FaskKAN is 3+ times faster than [efficient KAN](https://github.com/Blealtan/efficient-kan).
 
-The original implementation of KAN is available [here](https://github.com/KindXiaoming/pykan).
+The original implementation of KAN is [pykan](https://github.com/KindXiaoming/pykan).
 
-The implementation of efficient KAN is available [here](https://github.com/Blealtan/efficient-kan).
-
-Demo code and efficient_kan code in this repo is from efficient_kan thanks to Blealtan.
-
-The code is just a demo of how to approximately calculate Kolmogorov-Arnold Networks, with demo quality.
+FastKAN:
 
 1. Used Gaussian Radial Basis Functions to approximate the B-spline basis, which is the bottleneck of KAN and efficient KAN:
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ The rationale of doing so is that these RBF functions well approximate the B-spl
 
 2. Used LayerNorm to scale inputs to the range of spline grids, so there is no need to adjust the grids.
 
-3. FastKAN is 2.54x compared with efficient_kan in forward speed. (see [notebook](test_running_time.ipynb), 690us -> 272us on V100)
+3. FastKAN is 3.20x compared with efficient_kan in forward speed. (see [notebook](test_running_time.ipynb), 726us -> 227us on V100)
 
 More importantly this approximation suggests that KAN is equivalent to adding an RBF transformation to the inputs some place in the model. Someone may dig deeper into this for expression or approximation theories.

--- a/fastkan/fastkan.py
+++ b/fastkan/fastkan.py
@@ -56,7 +56,7 @@ class FastKANLayer(nn.Module):
             spline_basis = self.rbf(x)
         ret = self.spline_linear(spline_basis.view(*spline_basis.shape[:-2], -1))
         if self.use_base_update:
-            base = self.base_linear(self.base_activation(x))
+            base = self.base_linear(self.base_activation()(x))
             ret = ret + base
         return ret
 


### PR DESCRIPTION
fix #2 

On running this branch
```
(kan) shubham@Shubhams-MBP fast-kan % python train_mnist.py
100%|█████████████████████████████████████████████████████████████████| 938/938 [00:14<00:00, 65.34it/s, accuracy=0.875, loss=0.322, lr=0.001]
Epoch 1, Val Loss: 0.18690546661923835, Val Accuracy: 0.9418789808917197
100%|████████████████████████████████████████████████████████████████| 938/938 [00:10<00:00, 92.52it/s, accuracy=0.906, loss=0.193, lr=0.0008]
Epoch 2, Val Loss: 0.13573137449788725, Val Accuracy: 0.9581011146496815
100%|██████████████████████████████████████████████████████████████████| 938/938 [00:09<00:00, 96.98it/s, accuracy=1, loss=0.0178, lr=0.00064]
Epoch 3, Val Loss: 0.11036641830667426, Val Accuracy: 0.9666600318471338
100%|██████████████████████████████████████████████████████████████| 938/938 [00:10<00:00, 93.62it/s, accuracy=0.969, loss=0.103, lr=0.000512]
Epoch 4, Val Loss: 0.12479777913540602, Val Accuracy: 0.963077229299363
100%|████████████████████████████████████████████████████████████████| 938/938 [00:10<00:00, 93.20it/s, accuracy=0.906, loss=0.15, lr=0.00041]
Epoch 5, Val Loss: 0.10201086082264402, Val Accuracy: 0.9699442675159236
100%|█████████████████████████████████████████████████████████████████| 938/938 [00:10<00:00, 92.12it/s, accuracy=1, loss=0.0608, lr=0.000328]
Epoch 6, Val Loss: 0.08933244592337394, Val Accuracy: 0.9738256369426752
100%|█████████████████████████████████████████████████████████████| 938/938 [00:09<00:00, 99.05it/s, accuracy=0.969, loss=0.0446, lr=0.000262]
Epoch 7, Val Loss: 0.08981025442655294, Val Accuracy: 0.9739251592356688
100%|█████████████████████████████████████████████████████████████| 938/938 [00:09<00:00, 100.00it/s, accuracy=0.969, loss=0.0589, lr=0.00021]
Epoch 8, Val Loss: 0.08784118677857614, Val Accuracy: 0.9736265923566879
100%|█████████████████████████████████████████████████████████████████| 938/938 [00:09<00:00, 95.78it/s, accuracy=1, loss=0.0105, lr=0.000168]
Epoch 9, Val Loss: 0.08489166792043912, Val Accuracy: 0.9745222929936306
100%|████████████████████████████████████████████████████████████████| 938/938 [00:10<00:00, 89.73it/s, accuracy=1, loss=0.00687, lr=0.000134]
Epoch 10, Val Loss: 0.08321504555657434, Val Accuracy: 0.9764132165605095
```